### PR TITLE
fix: update renovate base branch config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -171,7 +171,7 @@
       "versioningTemplate": "docker"
     }
   ],
-  "baseBranchPatterns": [
+  "baseBranches": [
     "develop"
   ]
 }


### PR DESCRIPTION
## Summary
- replace deprecated Renovate `baseBranchPatterns` with `baseBranches`
- keeps Renovate targeting `develop` with current Renovate validator versions

## Verification
- podman run --rm -v "$PWD:/repo:z" -w /repo docker.io/renovate/renovate:41.0.0 renovate-config-validator