### PR TITLE
fix(container): verify downloaded devtools binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,54 +16,73 @@ ARG GH_VERSION=2.95.0
 USER 0
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+COPY scripts/container-download-verified.sh /usr/local/lib/container-download-verified.sh
+
 RUN dnf -y update && \
     dnf -y install --allowerasing ca-certificates curl unzip tar dnf-plugins-core && \
     curl -fsSL https://download.docker.com/linux/centos/docker-ce.repo -o /etc/yum.repos.d/docker-ce.repo && \
     dnf -y install docker-ce-cli docker-compose-plugin && \
-    dnf clean all && rm -rf /var/cache/yum
+    dnf clean all && rm -rf /var/cache/dnf /var/cache/yum
 
 # Map docker arch naming
-RUN case "${TARGETARCH}" in \
-      amd64)  export ARCH=amd64   DOCKER_ARCH=x86_64  ;; \
-      arm64)  export ARCH=arm64   DOCKER_ARCH=aarch64 ;; \
-      *) echo "Unsupported TARGETARCH=${TARGETARCH}" && exit 1 ;; \
-    esac && \
-    echo "ARCH=${ARCH} DOCKER_ARCH=${DOCKER_ARCH}" > /tmp/arch.env
+RUN source /usr/local/lib/container-download-verified.sh && \
+    detect_container_arch && \
+    echo "ARCH=${CONTAINER_ARCH} DOCKER_ARCH=${CONTAINER_RPM_ARCH}" > /tmp/arch.env
 
 # Terraform
-RUN source /tmp/arch.env && \
-    curl -fsSLo /tmp/terraform.zip \
-      "https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${ARCH}.zip" && \
+RUN source /usr/local/lib/container-download-verified.sh && \
+    source /tmp/arch.env && \
+    download_verified \
+      "https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${ARCH}.zip" \
+      /tmp/terraform.zip \
+      "https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_SHA256SUMS" \
+      "terraform_${TF_VERSION}_linux_${ARCH}.zip" && \
     unzip -q /tmp/terraform.zip -d /usr/local/bin && \
     rm -f /tmp/terraform.zip
 
 # TFLint
-RUN source /tmp/arch.env && \
-    curl -fsSLo /tmp/tflint.zip \
-      "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_${ARCH}.zip" && \
+RUN source /usr/local/lib/container-download-verified.sh && \
+    source /tmp/arch.env && \
+    download_verified \
+      "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_${ARCH}.zip" \
+      /tmp/tflint.zip \
+      "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/checksums.txt" \
+      "tflint_linux_${ARCH}.zip" && \
     unzip -q /tmp/tflint.zip -d /usr/local/bin && \
     rm -f /tmp/tflint.zip
 
 # terraform-docs
-RUN source /tmp/arch.env && \
-    curl -fsSLo /tmp/terraform-docs.tar.gz \
-      "https://github.com/terraform-docs/terraform-docs/releases/download/v${TF_DOCS_VERSION}/terraform-docs-v${TF_DOCS_VERSION}-linux-${ARCH}.tar.gz" && \
+RUN source /usr/local/lib/container-download-verified.sh && \
+    source /tmp/arch.env && \
+    download_verified \
+      "https://github.com/terraform-docs/terraform-docs/releases/download/v${TF_DOCS_VERSION}/terraform-docs-v${TF_DOCS_VERSION}-linux-${ARCH}.tar.gz" \
+      /tmp/terraform-docs.tar.gz \
+      "https://github.com/terraform-docs/terraform-docs/releases/download/v${TF_DOCS_VERSION}/terraform-docs-v${TF_DOCS_VERSION}.sha256sum" \
+      "terraform-docs-v${TF_DOCS_VERSION}-linux-${ARCH}.tar.gz" && \
     tar -xzf /tmp/terraform-docs.tar.gz -C /usr/local/bin terraform-docs && \
     chmod +x /usr/local/bin/terraform-docs && \
     rm -f /tmp/terraform-docs.tar.gz
 
 # Helm
-RUN source /tmp/arch.env && \
-    curl -fsSLo /tmp/helm.tar.gz \
-      "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCH}.tar.gz" && \
+RUN source /usr/local/lib/container-download-verified.sh && \
+    source /tmp/arch.env && \
+    download_verified \
+      "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCH}.tar.gz" \
+      /tmp/helm.tar.gz \
+      "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCH}.tar.gz.sha256sum" \
+      "helm-v${HELM_VERSION}-linux-${ARCH}.tar.gz" && \
     tar -xzf /tmp/helm.tar.gz -C /tmp && \
     install -m 0755 "/tmp/linux-${ARCH}/helm" /usr/local/bin/helm && \
     rm -rf /tmp/helm.tar.gz "/tmp/linux-${ARCH}"
 
 # GitHub CLI
-RUN source /tmp/arch.env && \
-    curl -fsSLo /tmp/gh.tar.gz \
-      "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" && \
+RUN source /usr/local/lib/container-download-verified.sh && \
+    source /tmp/arch.env && \
+    download_verified \
+      "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" \
+      /tmp/gh.tar.gz \
+      "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_checksums.txt" \
+      "gh_${GH_VERSION}_linux_${ARCH}.tar.gz" && \
     tar -xzf /tmp/gh.tar.gz -C /tmp && \
     install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${ARCH}/bin/gh" /usr/local/bin/gh && \
     rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_${ARCH}"
@@ -83,9 +102,9 @@ RUN install -m 0755 /usr/bin/docker /usr/local/bin/docker && \
 FROM registry.access.redhat.com/ubi9/python-311@sha256:a0bdb55576fc5b8d6704279307817828ef027e1065533ceba133fe9516003a6c
 
 LABEL maintainer="Lightning IT"
-LABEL org.opencontainers.image.title="ee-wunder-ansible-ubi9"
-LABEL org.opencontainers.image.description="Ansible Execution Environment (UBI 9) for Wunder automation."
-LABEL org.opencontainers.image.source="https://github.com/lightning-it/container-ee-wunder-ansible-ubi9"
+LABEL org.opencontainers.image.title="ee-wunder-devtools-ubi9"
+LABEL org.opencontainers.image.description="Devtools Execution Environment (UBI 9) for Wunder automation."
+LABEL org.opencontainers.image.source="https://github.com/lightning-it/container-ee-wunder-devtools-ubi9"
 
 ARG ANSIBLE_CORE_VERSION=2.21.1
 ARG PIP_VERSION=25.3
@@ -130,7 +149,7 @@ RUN dnf -y update && \
       --enablerepo="centos-stream-${CENTOS_STREAM_VERSION}-crb" \
       qemu-img guestfs-tools libguestfs && \
     rm -f /etc/yum.repos.d/centos-stream-vm-image-tools.repo && \
-    dnf clean all && rm -rf /var/cache/yum
+    dnf clean all && rm -rf /var/cache/dnf /var/cache/yum
 
 # Copy toolchain from builder (no curl/unzip in final image)
 COPY --from=tools /usr/local/bin/terraform /usr/local/bin/terraform

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Use it as a stable execution environment for:
 - CI pipelines
 - Integration tests (e.g. against local Keycloak containers)
 
-> Current image: `quay.io/l-it/ee-wunder-devtools-ubi9:v1.8.8`
+> Current image: `quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2`
 
 ---
 
@@ -57,31 +57,31 @@ Use it as a stable execution environment for:
 ### Start an interactive shell
 
 ```bash
-docker run --rm -it -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtools-ubi9:v1.8.8
+docker run --rm -it -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2
 ```
 
 ### Run Ansible commands
 
 ```bash
-docker run --rm -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtools-ubi9:v1.8.8 ansible-lint
+docker run --rm -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2 ansible-lint
 ```
 
 ```bash
-docker run --rm -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtools-ubi9:v1.8.8 ansible-playbook -i <inventory.yml> <playbook.yml>
+docker run --rm -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2 ansible-playbook -i <inventory.yml> <playbook.yml>
 ```
 
 ### Run Terraform tooling
 
 ```bash
-docker run --rm -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtools-ubi9:v1.8.8 terraform fmt -recursive
+docker run --rm -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2 terraform fmt -recursive
 ```
 
 ```bash
-docker run --rm -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtools-ubi9:v1.8.8 tflint --recursive
+docker run --rm -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2 tflint --recursive
 ```
 
 ```bash
-docker run --rm -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtools-ubi9:v1.8.8 terraform-docs markdown table --output-file README.md --output-mode replace .
+docker run --rm -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2 terraform-docs markdown table --output-file README.md --output-mode replace .
 ```
 
 ### Run Helm commands
@@ -89,7 +89,7 @@ docker run --rm -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtoo
 Check Helm CLI:
 
 ```bash
-docker run --rm -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtools-ubi9:v1.8.8 helm version --short
+docker run --rm -v "$PWD":/workspace -w /workspace quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2 helm version --short
 ```
 
 Run against your local kubeconfig:
@@ -99,7 +99,7 @@ docker run --rm \
   -v "$PWD":/workspace -w /workspace \
   -v "$HOME/.kube:/home/wunder/.kube:Z" \
   -e KUBECONFIG=/home/wunder/.kube/config \
-  quay.io/l-it/ee-wunder-devtools-ubi9:v1.8.8 helm list -A
+  quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2 helm list -A
 ```
 
 ---
@@ -112,7 +112,7 @@ In your repositories you can add a small helper script, e.g. `scripts/wunder-dev
 #!/usr/bin/env bash
 set -euo pipefail
 
-IMAGE="quay.io/l-it/ee-wunder-devtools-ubi9:v1.8.8"
+IMAGE="quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2"
 
 docker run --rm \
   --entrypoint "" \
@@ -143,7 +143,7 @@ podman run --rm -it \
   -e COPR_OWNER=litroc \
   -e COPR_PROJECT=modulix \
   -e COPR_PACKAGE=modulix-automation-runtime \
-  quay.io/l-it/ee-wunder-devtools-ubi9:v1.8.8 \
+  quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2 \
   bash /workspace/packaging/rpm/configure-copr-scm.sh
 ```
 

--- a/scripts/container-download-verified.sh
+++ b/scripts/container-download-verified.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+detect_container_arch() {
+  local arch="${TARGETARCH:-}"
+
+  if [ -z "$arch" ]; then
+    case "$(uname -m)" in
+      x86_64) arch="amd64" ;;
+      aarch64|arm64) arch="arm64" ;;
+      *)
+        echo "ERROR: unsupported build architecture: $(uname -m)" >&2
+        return 1
+        ;;
+    esac
+  fi
+
+  case "$arch" in
+    amd64)
+      CONTAINER_ARCH="amd64"
+      CONTAINER_RPM_ARCH="x86_64"
+      ;;
+    arm64)
+      CONTAINER_ARCH="arm64"
+      CONTAINER_RPM_ARCH="aarch64"
+      ;;
+    *)
+      echo "ERROR: unsupported TARGETARCH=${arch}" >&2
+      return 1
+      ;;
+  esac
+
+  export CONTAINER_ARCH CONTAINER_RPM_ARCH
+}
+
+download_verified() {
+  local url="$1"
+  local output_path="$2"
+  local checksum_url="$3"
+  local checksum_name="${4:-$(basename "$url")}"
+  local checksum_file
+  local expected
+
+  if [ -z "$checksum_url" ]; then
+    echo "ERROR: checksum URL is required for ${url}" >&2
+    return 1
+  fi
+
+  checksum_file="$(mktemp)"
+  curl --fail --show-error --silent --location --retry 5 --retry-delay 2 \
+    --output "$output_path" "$url"
+  curl --fail --show-error --silent --location --retry 5 --retry-delay 2 \
+    --output "$checksum_file" "$checksum_url"
+
+  expected="$(
+    awk -v wanted="$checksum_name" '
+      NF == 1 && $1 ~ /^[A-Fa-f0-9]{64}$/ {
+        print $1
+        exit
+      }
+      NF >= 2 {
+        file = $2
+        sub(/^\*/, "", file)
+        base = file
+        sub(/^.*\//, "", base)
+        if (file == wanted || base == wanted) {
+          print $1
+          exit
+        }
+      }
+    ' "$checksum_file"
+  )"
+
+  rm -f "$checksum_file"
+
+  if [ -z "$expected" ]; then
+    echo "ERROR: checksum for ${checksum_name} not found in ${checksum_url}" >&2
+    return 1
+  fi
+
+  printf '%s  %s\n' "$expected" "$output_path" | sha256sum --check --status
+}

--- a/scripts/devtools-container-ci.sh
+++ b/scripts/devtools-container-ci.sh
@@ -65,6 +65,12 @@ run_yaml_checks() {
   yamllint .
 }
 
+run_shellcheck() {
+  if compgen -G "scripts/*.sh" >/dev/null; then
+    shellcheck scripts/*.sh
+  fi
+}
+
 run_actionlint() {
   require_docker
   set_nested_workspace_args
@@ -262,6 +268,7 @@ run_semantic_release_dry_run() {
 
 run_ci() {
   run_yaml_checks
+  run_shellcheck
   run_actionlint
   run_hadolint
   run_container_build

--- a/scripts/ee-entrypoint.sh
+++ b/scripts/ee-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  set -- /bin/bash
+fi
+
+if ! whoami >/dev/null 2>&1; then
+  uid="$(id -u)"
+  gid="$(id -g)"
+  home="${HOME:-/tmp}"
+
+  export NSS_WRAPPER_PASSWD="${TMPDIR:-/tmp}/passwd.nss_wrapper"
+  export NSS_WRAPPER_GROUP="${TMPDIR:-/tmp}/group.nss_wrapper"
+
+  (cat /etc/passwd 2>/dev/null || true) > "$NSS_WRAPPER_PASSWD"
+  echo "eeuser:x:${uid}:${gid}:EE User:${home}:/bin/bash" >> "$NSS_WRAPPER_PASSWD"
+
+  (cat /etc/group 2>/dev/null || true) > "$NSS_WRAPPER_GROUP"
+  echo "eegroup:x:${gid}:" >> "$NSS_WRAPPER_GROUP"
+
+  wrapper="/usr/lib64/libnss_wrapper.so"
+  if [ -f "$wrapper" ]; then
+    export LD_PRELOAD="${wrapper}${LD_PRELOAD:+:${LD_PRELOAD}}"
+  fi
+fi
+
+exec "$@"

--- a/scripts/install-galaxy-content.sh
+++ b/scripts/install-galaxy-content.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:?usage: install-galaxy-content.sh collections|controller|roles}"
+profile="${COLLECTION_PROFILE:-public}"
+collection_opts="${ANSIBLE_GALAXY_CLI_COLLECTION_OPTS:-}"
+collection_args=()
+attempts="${ANSIBLE_GALAXY_INSTALL_RETRIES:-5}"
+delay="${ANSIBLE_GALAXY_RETRY_DELAY_SECONDS:-10}"
+hub_url="${AUTOMATION_HUB_URL:-https://console.redhat.com/api/automation-hub/content/published/}"
+hub_sso_url="${AUTOMATION_HUB_SSO_URL:-${AUTOMATION_HUB_TOKEN_URL:-${AUTOMATION_HUB_AUTH_URL:-https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token}}}"
+config_path="/tmp/ansible-galaxy.cfg"
+
+if [ -n "$collection_opts" ]; then
+  read -r -a collection_args <<< "$collection_opts"
+fi
+
+install_with_retry() {
+  local try=1
+
+  until "$@"; do
+    if [ "$try" -ge "$attempts" ]; then
+      return 1
+    fi
+    echo "ansible-galaxy failed (attempt ${try}/${attempts}); retrying in ${delay}s..."
+    sleep "$delay"
+    try=$((try + 1))
+  done
+}
+
+galaxy_cmd() {
+  if [ -f "$config_path" ]; then
+    ANSIBLE_CONFIG="$config_path" ansible-galaxy "$@"
+  else
+    ansible-galaxy "$@"
+  fi
+}
+
+has_collection_requirements() {
+  grep -Eq '^[[:space:]]*collections:[[:space:]]*$|^[[:space:]]*-[[:space:]]*name:' "$1"
+}
+
+has_role_requirements() {
+  grep -Eq '^[[:space:]]*-[[:space:]]*(src|name):' "$1"
+}
+
+read_automation_hub_token() {
+  local token_file="/run/secrets/rh_automation_hub_token"
+
+  if [ ! -s "$token_file" ]; then
+    echo "ERROR: missing required build secret for certified profile: rh_automation_hub_token" >&2
+    return 1
+  fi
+
+  token="$(tr -d '\r\n' < "$token_file")"
+  if [ -z "$token" ]; then
+    echo "ERROR: build secret rh_automation_hub_token is empty" >&2
+    return 1
+  fi
+}
+
+configure_automation_hub() {
+  read_automation_hub_token
+  {
+    echo "[galaxy]"
+    echo "server_list = automation_hub,galaxy"
+    echo
+    echo "[galaxy_server.automation_hub]"
+    echo "url=${hub_url}"
+    echo "auth_url=${hub_sso_url}"
+    echo "token=${token}"
+    echo
+    echo "[galaxy_server.galaxy]"
+    echo "url=https://galaxy.ansible.com/"
+  } > "$config_path"
+}
+
+validate_profile() {
+  case "$profile" in
+    public|certified|bootstrap) ;;
+    *)
+      echo "ERROR: invalid COLLECTION_PROFILE='${profile}' (use: public|certified|bootstrap)" >&2
+      return 1
+      ;;
+  esac
+}
+
+install_collections() {
+  local base_req="/build/collections-requirements-base.yml"
+  local certified_req="/build/collections-requirements-certified-extra.yml"
+
+  validate_profile
+
+  case "$profile" in
+    bootstrap)
+      echo "COLLECTION_PROFILE=bootstrap selected: skipping collections install"
+      ;;
+    public|certified)
+      if [ ! -f "$base_req" ]; then
+        echo "ERROR: base collections requirements file not found: ${base_req}" >&2
+        return 1
+      fi
+      install_with_retry galaxy_cmd collection install "${collection_args[@]}" \
+        -r "$base_req" \
+        --collections-path /usr/share/ansible/collections
+      ;;
+  esac
+
+  if [ "$profile" = "certified" ]; then
+    if [ ! -f "$certified_req" ]; then
+      echo "ERROR: certified extra requirements file not found: ${certified_req}" >&2
+      return 1
+    fi
+    configure_automation_hub
+    install_with_retry galaxy_cmd collection install "${collection_args[@]}" \
+      -r "$certified_req" \
+      --collections-path /usr/share/ansible/collections
+  fi
+
+  galaxy_cmd collection list -p /usr/share/ansible/collections
+}
+
+install_controller_collections() {
+  local req="/build/controller-requirements.yml"
+
+  validate_profile
+
+  if ! has_collection_requirements "$req"; then
+    echo "No controller collections to install (${req} empty or no valid entries). Skipping."
+    return 0
+  fi
+
+  if [ "$profile" = "bootstrap" ]; then
+    echo "COLLECTION_PROFILE=bootstrap selected: skipping controller collections install"
+    return 0
+  fi
+
+  if [ "$profile" = "certified" ]; then
+    configure_automation_hub
+  fi
+
+  install_with_retry galaxy_cmd collection install "${collection_args[@]}" \
+    -r "$req" \
+    --collections-path /usr/share/automation-controller/collections
+  galaxy_cmd collection list -p /usr/share/automation-controller/collections
+}
+
+install_roles() {
+  local req="/build/roles-requirements.yml"
+
+  if has_role_requirements "$req"; then
+    ansible-galaxy role install \
+      -r "$req" \
+      -p /usr/share/ansible/roles
+    ansible-galaxy role list -p /usr/share/ansible/roles
+  else
+    echo "No roles to install (${req} empty or no valid entries). Skipping."
+  fi
+}
+
+trap 'rm -f "$config_path"' EXIT
+
+case "$mode" in
+  collections) install_collections ;;
+  controller) install_controller_collections ;;
+  roles) install_roles ;;
+  *)
+    echo "ERROR: unsupported mode '${mode}' (use: collections|controller|roles)" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/wunder-devtools-ee.sh
+++ b/scripts/wunder-devtools-ee.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-IMAGE="quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.0"
+IMAGE="quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2"
 CONTAINER_HOME="${CONTAINER_HOME:-/tmp/wunder}"
 HOST_HOME_CACHE_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/wunder-devtools-ee/v2/home"
 HOST_HOME_CACHE_SCOPE="host-uid-$(id -u)"


### PR DESCRIPTION
## Summary
- verify Terraform, TFLint, terraform-docs, Helm, and GitHub CLI downloads with upstream checksums
- consume shared container helper scripts
- update devtools wrapper/docs to ee-wunder-devtools-ubi9:v1.9.2
- keep final image labels aligned with the devtools repo

## Verification
- WUNDER_DEVTOOLS_STRICT=1 WUNDER_CONTAINER_ENGINE=podman scripts/wunder-devtools-ee.sh shellcheck scripts/*.sh
- WUNDER_DEVTOOLS_STRICT=1 WUNDER_CONTAINER_ENGINE=podman scripts/wunder-devtools-ee.sh scripts/devtools-container-ci.sh ci
- pre-commit run --all-files