### PR TITLE
Install actionlint in devtools container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ARG TFLINT_VERSION=0.63.1
 ARG TF_DOCS_VERSION=0.24.0
 ARG HELM_VERSION=4.2.2
 ARG GH_VERSION=2.95.0
+ARG ACTIONLINT_VERSION=1.7.12
 
 # hadolint ignore=DL3002
 USER 0
@@ -87,6 +88,18 @@ RUN source /usr/local/lib/container-download-verified.sh && \
     install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${ARCH}/bin/gh" /usr/local/bin/gh && \
     rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_${ARCH}"
 
+# actionlint
+RUN source /usr/local/lib/container-download-verified.sh && \
+    source /tmp/arch.env && \
+    download_verified \
+      "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${ARCH}.tar.gz" \
+      /tmp/actionlint.tar.gz \
+      "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt" \
+      "actionlint_${ACTIONLINT_VERSION}_linux_${ARCH}.tar.gz" && \
+    tar -xzf /tmp/actionlint.tar.gz -C /tmp actionlint && \
+    install -m 0755 /tmp/actionlint /usr/local/bin/actionlint && \
+    rm -f /tmp/actionlint.tar.gz /tmp/actionlint
+
 # Docker CLI + Compose plugin (from docker-ce packages)
 RUN install -m 0755 /usr/bin/docker /usr/local/bin/docker && \
     mkdir -p /usr/local/lib/docker/cli-plugins && \
@@ -157,6 +170,7 @@ COPY --from=tools /usr/local/bin/tflint /usr/local/bin/tflint
 COPY --from=tools /usr/local/bin/terraform-docs /usr/local/bin/terraform-docs
 COPY --from=tools /usr/local/bin/helm /usr/local/bin/helm
 COPY --from=tools /usr/local/bin/gh /usr/local/bin/gh
+COPY --from=tools /usr/local/bin/actionlint /usr/local/bin/actionlint
 COPY --from=tools /usr/local/bin/docker /usr/local/bin/docker
 COPY --from=tools /usr/local/lib/docker/cli-plugins/docker-compose /usr/local/lib/docker/cli-plugins/docker-compose
 
@@ -166,7 +180,7 @@ RUN python -m pip install --no-cache-dir --upgrade "pip==${PIP_VERSION}" && \
     python -m pip install --no-cache-dir -r /tmp/requirements.txt && \
     rm -f /tmp/requirements.txt && \
     ansible --version && ansible-galaxy --version && antsibull-changelog --version && \
-    shellcheck --version && helm version --short && gh --version && \
+    shellcheck --version && actionlint --version && helm version --short && gh --version && \
     copr-cli --version && rpmspec --version && qemu-img --version && \
     virt-customize --version && virt-sysprep --version && guestfish --version
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ development. It is based on **Red Hat UBI 9** and includes:
 - antsibull-changelog
 - yamllint
 - ShellCheck
+- actionlint
 - Terraform CLI
 - TFLint
 - terraform-docs
@@ -38,6 +39,7 @@ Use it as a stable execution environment for:
   - `antsibull-changelog`
   - `yamllint`
   - `shellcheck`
+  - `actionlint`
   - `terraform`
   - `tflint`
   - `terraform-docs`
@@ -128,8 +130,8 @@ chmod +x scripts/wunder-devtools-ee.sh
 ```
 
 Then use it in `pre-commit`, Makefiles or CI jobs to run `ansible-lint`, `yamllint`,
-`shellcheck`, `terraform`, `tflint`, `terraform-docs`, `helm`, `copr-cli`, RPM tooling,
-and VM image tooling in a consistent environment.
+`shellcheck`, `actionlint`, `terraform`, `tflint`, `terraform-docs`, `helm`,
+`copr-cli`, RPM tooling, and VM image tooling in a consistent environment.
 
 ### Configure COPR from the container
 

--- a/renovate.json
+++ b/renovate.json
@@ -146,6 +146,20 @@
     },
     {
       "customType": "regex",
+      "description": "actionlint version pin in Dockerfile",
+      "managerFilePatterns": [
+        "/Dockerfile/"
+      ],
+      "matchStrings": [
+        "ACTIONLINT_VERSION=(?<currentValue>[0-9.]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "rhysd/actionlint",
+      "extractVersionTemplate": "^v(?<version>[0-9.]+)$",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
       "description": "ansible-core version pin in Dockerfile",
       "managerFilePatterns": [
         "/Dockerfile/"

--- a/scripts/devtools-container-ci.sh
+++ b/scripts/devtools-container-ci.sh
@@ -72,6 +72,11 @@ run_shellcheck() {
 }
 
 run_actionlint() {
+  if command -v actionlint >/dev/null 2>&1; then
+    actionlint
+    return
+  fi
+
   require_docker
   set_nested_workspace_args
   docker run --rm \
@@ -148,6 +153,7 @@ run_contract_tests() {
         ansible-lint --version
         pre-commit --version
         gh --version
+        actionlint --version
         docker --version
         antsibull-changelog --version
       '


### PR DESCRIPTION
## Summary
- install pinned actionlint in the devtools image with release checksum verification
- prefer the local actionlint binary in the CI helper while keeping the container fallback
- include actionlint in the image contract check and Renovate version tracking

## Verification
- `yamllint .`
- `bash -n scripts/devtools-container-ci.sh`
- `python3 -m json.tool renovate.json >/dev/null`