### PR TITLE
chore: fix container workflow badges

### DIFF
--- a/.lit/repository.yml
+++ b/.lit/repository.yml
@@ -27,6 +27,8 @@ galaxy_publish: false
 quay_publish: true
 release_evidence: true
 heavy_incus_required: false
+trivy_required: true
+trivy_release_gate: true
 readme_badges:
   - ci
   - container-build
@@ -38,5 +40,6 @@ workflows:
   ci: container-ci.yml
   container_build: container-build.yml
   release: container-build-publish.yml
+  trivy: container-trivy.yml
   promote: promote-develop-to-main.yml
   backmerge: sync-main-to-develop.yml

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Publishing targets: `github-release, quay.io`.
 [![Latest Release](https://img.shields.io/github/v/release/lightning-it/container-ee-wunder-devtools-ubi9?sort=semver)](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/releases/latest)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/lightning-it/container-ee-wunder-devtools-ubi9/badge)](https://scorecard.dev/viewer/?uri=github.com/lightning-it/container-ee-wunder-devtools-ubi9)
 [![Quay.io](https://quay.io/repository/l-it/ee-wunder-devtools-ubi9/status)](https://quay.io/repository/l-it/ee-wunder-devtools-ubi9)
-[![Trivy](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/actions/workflows/container-build-publish.yml/badge.svg?branch=main)](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/actions/workflows/container-build-publish.yml)
-[![Container Build](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/actions/workflows/container-build-publish.yml/badge.svg?branch=main)](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/actions/workflows/container-build-publish.yml)
+[![Trivy](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/actions/workflows/container-trivy.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/actions/workflows/container-trivy.yml)
+[![Container Build](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/actions/workflows/container-build.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/actions/workflows/container-build.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
 <!-- END LIT_QUALITY_BADGES -->


### PR DESCRIPTION
## Summary
- map Trivy README badges to container-trivy.yml
- map Container Build README badges to container-build.yml
- avoid duplicate badge labels pointing at container-build-publish.yml

## Tests
- shared-assets-lit: python3 scripts/audit-release-model.py
- shared-assets-lit: python3 scripts/audit-container-trivy.py
- shared-assets-lit: python3 scripts/lit-repository-quality.py