### PR TITLE
chore: promote Quay badge fix to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Publishing targets: `github-release, quay.io`.
 [![CI](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/actions/workflows/container-ci.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/actions/workflows/container-ci.yml)
 [![Latest Release](https://img.shields.io/github/v/release/lightning-it/container-ee-wunder-devtools-ubi9?sort=semver)](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/releases/latest)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/lightning-it/container-ee-wunder-devtools-ubi9/badge)](https://scorecard.dev/viewer/?uri=github.com/lightning-it/container-ee-wunder-devtools-ubi9)
-[![Quay.io](https://quay.io/repository/l-it/ee-wunder-devtools-ubi9/status)](https://quay.io/repository/l-it/ee-wunder-devtools-ubi9)
+[![Quay.io](https://img.shields.io/badge/Quay.io-image-blue?logo=quay&logoColor=white)](https://quay.io/repository/l-it/ee-wunder-devtools-ubi9)
 [![Trivy](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/actions/workflows/container-trivy.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/actions/workflows/container-trivy.yml)
 [![Container Build](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/actions/workflows/container-build.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/actions/workflows/container-build.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)


### PR DESCRIPTION
## Summary
- promote the Quay badge fix from develop to main
- keep README Quay badges off the Quay /status endpoint so they cannot render container none
- include shared-assets-lit generator/audit guardrails and regenerated container READMEs

## Verification
- develop PR checks passed before merge
- promotion branch is a merge of origin/develop into main