### PR TITLE
fix: allow guarded automerge to enable auto-merge

### DIFF
--- a/.github/workflows/renovate-guarded-automerge.yml
+++ b/.github/workflows/renovate-guarded-automerge.yml
@@ -15,6 +15,9 @@ jobs:
     name: Approve trusted Renovate PR
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Verify Renovate PR identity

--- a/.github/workflows/shared-assets-guarded-automerge.yml
+++ b/.github/workflows/shared-assets-guarded-automerge.yml
@@ -15,6 +15,9 @@ jobs:
     name: Approve trusted shared-assets PR
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Verify shared-assets PR identity


### PR DESCRIPTION
Restores job-scoped contents: write for trusted guarded automerge jobs. The workflow default remains contents: read, but GitHub requires contents write for enablePullRequestAutoMerge.\n\nValidation:\n- yamllint guarded automerge workflows\n- actionlint guarded automerge workflows