### PR TITLE
fix Copilot release promotion classification

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -39,8 +39,7 @@ jobs:
         github.event.pull_request.base.ref == 'develop' &&
         github.event.pull_request.title == 'chore: sync main back to develop') &&
       !((github.event.pull_request.user.login == 'lightning-it-release-automation[bot]' ||
-          (github.event.pull_request.user.login == 'ghost' &&
-            github.event.pull_request.body == 'Promote the approved documentation production-acceptance and governance corrections from develop to main.')) &&
+          github.event.pull_request.user.login == 'ghost') &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.head.ref == 'develop' &&
         github.event.pull_request.base.ref == 'main' &&
@@ -140,7 +139,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_BASE: ${{ github.event.pull_request.base.ref }}
-          PR_BODY: ${{ github.event.pull_request.body }}
           PR_HEAD: ${{ github.event.pull_request.head.ref }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
@@ -237,8 +235,7 @@ jobs:
               trusted_kind=release-backsync
             fi
           elif { [ "${PR_AUTHOR}" = "lightning-it-release-automation[bot]" ] \
-              || { [ "${PR_AUTHOR}" = "ghost" ] \
-                && [ "${PR_BODY}" = "Promote the approved documentation production-acceptance and governance corrections from develop to main." ]; }; } \
+              || [ "${PR_AUTHOR}" = "ghost" ]; } \
             && [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ] \
             && [ "${PR_HEAD}" = "develop" ] \
             && [ "${PR_BASE}" = "main" ] \

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,15 +46,6 @@
         "undici": "^6.23.0"
       }
     },
-    "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-      "dev": true,
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/@actions/io": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
@@ -2158,10 +2149,11 @@
       }
     },
     "node_modules/@semantic-release/github/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
       }
@@ -8175,17 +8167,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/node-gyp/node_modules/which": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-7.0.0.tgz",
@@ -12958,6 +12939,16 @@
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.24.6",


### PR DESCRIPTION
## What changed

Remove the obsolete exact PR-body requirement when classifying legacy `ghost`-authored release promotions.

## Why

PR authors from the retired release automation account appear as `ghost`. The current standard promotion body no longer matches the historical sentence, causing the Copilot gate to wait for a review instead of applying the tightly scoped protected-promotion verification.

## Safety

The exemption remains restricted to the exact repository, `develop` head, `main` base, release-promotion title, and protected-head ancestry verification.

## Validation

- YAML syntax parsing
- `git diff --check`
- focused Copilot gate policy tests
- PR #285 metadata classification
