### PR TITLE
docs(governance): align container assurance with engineering ADRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Repository-wide ownership and mandatory review routing.
+* @lightning-it/ent:release
+
+/.github/ @lightning-it/ent:release
+/Dockerfile @lightning-it/ent:release
+/scripts/ @lightning-it/ent:release

--- a/OPENSSF.md
+++ b/OPENSSF.md
@@ -7,9 +7,13 @@ This repository follows the Lightning IT shared OpenSSF readiness model generate
 - [Repository Topology and Shared Engineering Assets](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878636297)
 - [Branching, Review and Release Governance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878603438)
 - [Mandatory CI Quality and Artifact Assurance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878636340)
+- [Distributed Test Ownership and Central Heavy Execution](https://lit.atlassian.net/wiki/spaces/LIT/pages/2886566105)
+- [ModuLix Lifecycle, Versioning and Release Evidence](https://lit.atlassian.net/wiki/spaces/LIT/pages/2886926524)
 - [Repository and Secure SDLC Standard](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887778335)
+- [Technology Engineering Standards](https://lit.atlassian.net/wiki/spaces/LIT/pages/2886762765)
 - [Quality Gates and Definition of Done](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887123058)
 - [OpenSSF and Software Supply Chain Assurance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887024876)
+- [Compliance Gaps and Migration Roadmap](https://lit.atlassian.net/wiki/spaces/LIT/pages/2886926554)
 
 ## Repository
 

--- a/OPENSSF.md
+++ b/OPENSSF.md
@@ -2,6 +2,15 @@
 
 This repository follows the Lightning IT shared OpenSSF readiness model generated from `lightning-it/shared-assets-lit`.
 
+## Governing Decisions And Standards
+
+- [Repository Topology and Shared Engineering Assets](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878636297)
+- [Branching, Review and Release Governance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878603438)
+- [Mandatory CI Quality and Artifact Assurance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878636340)
+- [Repository and Secure SDLC Standard](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887778335)
+- [Quality Gates and Definition of Done](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887123058)
+- [OpenSSF and Software Supply Chain Assurance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887024876)
+
 ## Repository
 
 - Repository: `container-ee-wunder-devtools-ubi9`


### PR DESCRIPTION
Tracks #360 after merge and live-policy verification.

- adds repository-wide CODEOWNERS routing
- links the generated OpenSSF guidance directly to the governing ADRs and standards
- preserves the existing digest-pinned build, Trivy release gate, Buildx SBOM/provenance, keyless image signing, signature verification, and signed release evidence
- pairs with lightning-it/github-management-lit#183, which makes Trivy, one approval, and CODEOWNERS review enforceable on main and develop

Validation: git diff --check; existing container assurance implementation inspected against the issue acceptance criteria. This PR remains draft until CI and the central policy change are verified.