### PR TITLE
feat: add Copilot push-ready devtool parity

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Lightning IT Devtools UBI 9",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "context": ".."
+  },
+  "remoteUser": "wunder",
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+  "containerEnv": {
+    "HOME": "/tmp/wunder"
+  },
+  "runArgs": [
+    "--read-only",
+    "--cap-drop=ALL",
+    "--security-opt=no-new-privileges=true",
+    "--pids-limit=1024",
+    "--tmpfs=/tmp:rw,exec,nosuid,nodev,size=2g",
+    "--tmpfs=/run:rw,nosuid,nodev,size=256m"
+  ]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
   "containerEnv": {
     "HOME": "/tmp/wunder"
   },
+  "postStartCommand": "mkdir -p /tmp/wunder",
   "runArgs": [
     "--read-only",
     "--cap-drop=ALL",

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,3 +7,11 @@
 - Require new or modified third-party GitHub Actions dependencies to use immutable commit SHAs.
 - Explain each finding's impact and propose a concrete fix.
 - Prefer a regression test for bugs and security issues.
+- Treat `AGENTS.md` as the canonical repository contract. A managed
+  `AGENTS_SHA256` marker below binds these instructions to the reviewed
+  `AGENTS.md`; instruction drift is a blocking finding.
+
+
+
+<!-- Managed contract: Codex and Copilot must apply AGENTS.md. -->
+<!-- AGENTS_SHA256: def99a1a6a26f43cb27acc40934a6feeb8697ce87ac37f0606adcbbf4c43b22b -->

--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -22,6 +22,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Verify Codex and Copilot instruction parity
+        run: python3 scripts/lit-push-ready.py instructions
+
       - name: Run container CI parity checks
         env:
           WUNDER_DEVTOOLS_DOCKER_SOCKET: required

--- a/.lit/push-ready.json
+++ b/.lit/push-ready.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "checks": [
+    {
+      "name": "container-ci-parity",
+      "command": [
+        "bash",
+        "scripts/devtools-container-ci.sh"
+      ]
+    },
+    {
+      "name": "diff-check",
+      "command": [
+        "git",
+        "diff",
+        "--check"
+      ]
+    }
+  ],
+  "remote_only_checks": [
+    "Quay authentication, publishing and release evidence attachment",
+    "GitHub OIDC keyless signing identity",
+    "GitHub-hosted runner and external registry availability",
+    "Required Copilot review on the pull request head SHA"
+  ],
+  "copilot": {
+    "max_diff_bytes": 200000
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
   - `LICENSE`
   - `CODE_OF_CONDUCT.md`
   - `scripts/wunder-devtools-ee.sh`
+  - `scripts/lit-push-ready.py`
 - Managed container baseline files from `shared-assets-lit/container/base`:
   - `AGENTS.md`
   - `.gitignore`
@@ -20,6 +21,7 @@
   - `.releaserc`
   - `.yamllint`
   - `CONTRIBUTING.md`
+  - `.lit/push-ready.json`
   - `.github/workflows/container-ci.yml`
   - `.github/workflows/container-build-publish.yml`
   - `.github/workflows/promote-develop-to-main.yml`
@@ -84,6 +86,18 @@
   in a YAML comment and ensure Renovate can maintain the pin.
 - Pin helper container images used by validation scripts; do not use `latest` for CI linters, scanners, or release
   tooling.
+
+## Push-ready validation
+
+- Before push, run `python3 scripts/lit-push-ready.py push-ready`.
+- `AGENTS.md` is the canonical Codex and Copilot contract.
+- `.github/copilot-instructions.md` must contain the current managed
+  `AGENTS_SHA256` binding.
+- A Copilot review is advisory input until Codex has resolved or dispositioned
+  every finding and rerun all affected deterministic checks.
+- Any content change after a successful review invalidates the local evidence.
+- GitHub Actions required checks and the current-head Copilot gate remain
+  authoritative for merge.
 
 ## Repo-specific overrides
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ ARG TF_DOCS_VERSION=0.24.0
 ARG HELM_VERSION=4.2.3
 ARG GH_VERSION=2.96.0
 ARG ACTIONLINT_VERSION=1.7.12
+ARG NODE_VERSION=22.23.1
+ARG NPM_VERSION=12.0.1
+ARG COPILOT_VERSION=1.0.74
 
 # hadolint ignore=DL3002
 USER 0
@@ -100,6 +103,26 @@ RUN source /usr/local/lib/container-download-verified.sh && \
     install -m 0755 /tmp/actionlint /usr/local/bin/actionlint && \
     rm -f /tmp/actionlint.tar.gz /tmp/actionlint
 
+# Node.js LTS and GitHub Copilot CLI. Node release checksums and npm's
+# package-integrity verification cover both supported target architectures.
+# Copilot's lifecycle script is required to install its bundled native binary.
+RUN source /usr/local/lib/container-download-verified.sh && \
+    source /tmp/arch.env && \
+    case "${ARCH}" in amd64) NODE_ARCH=x64 ;; arm64) NODE_ARCH=arm64 ;; *) exit 1 ;; esac && \
+    download_verified \
+      "https://nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
+      /tmp/node.tar.xz \
+      "https://nodejs.org/download/release/v${NODE_VERSION}/SHASUMS256.txt" \
+      "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
+    mkdir -p /opt/node && \
+    tar -xJf /tmp/node.tar.xz --strip-components=1 -C /opt/node && \
+    /opt/node/bin/npm install --global --prefix /opt/node "npm@${NPM_VERSION}" && \
+    /opt/node/bin/npm install --global --prefix /opt/node --ignore-scripts=false "@github/copilot@${COPILOT_VERSION}" && \
+    /opt/node/bin/node --version && \
+    /opt/node/bin/copilot --version && \
+    rm -f /tmp/node.tar.xz && \
+    /opt/node/bin/npm cache clean --force
+
 # Docker CLI + Compose plugin (from docker-ce packages)
 RUN install -m 0755 /usr/bin/docker /usr/local/bin/docker && \
     mkdir -p /usr/local/lib/docker/cli-plugins && \
@@ -173,6 +196,7 @@ COPY --from=tools /usr/local/bin/gh /usr/local/bin/gh
 COPY --from=tools /usr/local/bin/actionlint /usr/local/bin/actionlint
 COPY --from=tools /usr/local/bin/docker /usr/local/bin/docker
 COPY --from=tools /usr/local/lib/docker/cli-plugins/docker-compose /usr/local/lib/docker/cli-plugins/docker-compose
+COPY --from=tools /opt/node /opt/node
 
 # Python deps: this *is* the right place for pip
 COPY requirements.txt /tmp/requirements.txt
@@ -192,6 +216,7 @@ RUN useradd -m wunder && \
     chmod 1777 /tmp/ansible /tmp/ansible/tmp
 
 ENV HOME=/home/wunder \
+    PATH=/opt/node/bin:$PATH \
     ANSIBLE_LOCAL_TEMP=/tmp/ansible/tmp \
     ANSIBLE_REMOTE_TEMP=/tmp/ansible/tmp
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ development. It is based on **Red Hat UBI 9** and includes:
 - yamllint
 - ShellCheck
 - actionlint
+- GitHub Copilot CLI
 - Terraform CLI
 - TFLint
 - terraform-docs
@@ -69,6 +70,10 @@ Use it as a stable execution environment for:
 - CI pipelines
 - Integration tests (e.g. against local Keycloak containers)
 
+The repository also provides a digest-pinned
+[Dev Container and host acceptance matrix](docs/host-parity.md) for RHEL,
+Ubuntu, and macOS pipeline-parity work.
+
 > Current image: `quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2`
 
 ---
@@ -83,6 +88,7 @@ Use it as a stable execution environment for:
   - `yamllint`
   - `shellcheck`
   - `actionlint`
+  - `copilot`
   - `terraform`
   - `tflint`
   - `terraform-docs`

--- a/docs/host-parity.md
+++ b/docs/host-parity.md
@@ -1,0 +1,35 @@
+# Host parity and Dev Container support
+
+The repository Dev Container and the host-parity probe build the image from
+the current commit. Downstream repositories must continue to use an immutable
+published digest; their Dev Container reference is updated only after this
+change has been released.
+
+Managed baseline changes in this implementation are sourced by
+[shared-assets-lit#602](https://github.com/lightning-it/shared-assets-lit/pull/602);
+they are not downstream-only overrides.
+
+## Acceptance matrix
+
+| Host | Architecture | Runtime | Current evidence |
+| --- | --- | --- | --- |
+| RHEL supported major | x86_64 | Podman | Pending execution on the target host |
+| Ubuntu LTS | x86_64 | Docker | Pending execution on the target host |
+| macOS supported major | Apple Silicon | Docker Desktop | Pending execution on the target host |
+| macOS supported major | Apple Silicon | Podman machine | Provisional; not supported until separately proven |
+
+Run the host probe from a clean checkout:
+
+```bash
+bash scripts/verify-host-parity.sh
+```
+
+The command fails closed for unsupported hosts and runtimes, builds the current
+commit, launches it without a container-runtime socket, verifies the non-root
+toolchain including Node.js and Copilot CLI, and emits a JSON result. Store the
+output with the exact commit and workflow evidence in issue
+[container-ee-wunder-devtools-ubi9#361](https://github.com/lightning-it/container-ee-wunder-devtools-ubi9/issues/361).
+
+The Dev Container provides Linux toolchain parity. It does not prove
+host-kernel behavior or GitHub permissions, secrets, OIDC, registry
+availability, signing identity, or GitHub-hosted runner state.

--- a/renovate.json
+++ b/renovate.json
@@ -57,6 +57,30 @@
     },
     {
       "customType": "regex",
+      "description": "Node.js LTS version pin in Dockerfile",
+      "managerFilePatterns": ["/^Dockerfile$/"],
+      "matchStrings": ["ARG\\s+NODE_VERSION=(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\n"],
+      "datasourceTemplate": "node-version",
+      "depNameTemplate": "node"
+    },
+    {
+      "customType": "regex",
+      "description": "GitHub Copilot CLI version pin in Dockerfile",
+      "managerFilePatterns": ["/^Dockerfile$/"],
+      "matchStrings": ["ARG\\s+COPILOT_VERSION=(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\n"],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "@github/copilot"
+    },
+    {
+      "customType": "regex",
+      "description": "npm version pin in Dockerfile",
+      "managerFilePatterns": ["/^Dockerfile$/"],
+      "matchStrings": ["ARG\\s+NPM_VERSION=(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\n"],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "npm"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/^collections/requirements-base\\.yml$/", "/^collections/controller-requirements\\.yml$/"],
       "matchStrings": ["-\\s+name:\\s+(?<depName>[A-Za-z0-9_]+\\.[A-Za-z0-9_]+)\\s*\\n\\s+version:\\s+\"?(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\"?\\s*\\n"],
       "datasourceTemplate": "galaxy-collection",

--- a/scripts/devtools-container-ci.sh
+++ b/scripts/devtools-container-ci.sh
@@ -137,10 +137,6 @@ validate_container_input() {
   local path="$3"
   local resolved workspace_root
 
-  if ! command -v realpath >/dev/null 2>&1; then
-    echo "ERROR: realpath is required to validate configured container build paths." >&2
-    exit 1
-  fi
   if [ -z "$path" ] || [[ "$path" =~ [[:cntrl:]] ]]; then
     echo "ERROR: configured ${label} must be a non-empty path without control characters." >&2
     exit 1
@@ -163,7 +159,17 @@ validate_container_input() {
   esac
 
   workspace_root="$(pwd -P)"
-  if ! resolved="$(realpath -e -- "$path" 2>/dev/null)"; then
+  if ! resolved="$(
+    python3 - "$path" <<'PY'
+import pathlib
+import sys
+
+try:
+    print(pathlib.Path(sys.argv[1]).resolve(strict=True))
+except (OSError, RuntimeError):
+    raise SystemExit(1)
+PY
+  )"; then
     echo "ERROR: configured ${label} does not exist: ${path}" >&2
     exit 1
   fi
@@ -371,9 +377,13 @@ run_contract_tests() {
 
   case "$repo_name" in
     container-ee-wunder-devtools-ubi9)
-      docker run --rm "${validation_container_args[@]}" "$image" bash -lc '
+      # Copilot extracts and maps a signed native runtime from its cache.
+      docker run --rm "${validation_container_args[@]}" \
+        --tmpfs "/copilot-cache:rw,exec,nosuid,nodev,size=256m" \
+        -e XDG_CACHE_HOME=/copilot-cache \
+        "$image" bash -lc '
         set -euo pipefail
-        export XDG_CACHE_HOME=/tmp/.cache
+        export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/tmp/.cache}"
         mkdir -p "$XDG_CACHE_HOME"
         terraform -version
         tflint --version
@@ -382,6 +392,8 @@ run_contract_tests() {
         ansible-lint --version
         pre-commit --version
         gh --version
+        node --version
+        copilot --version
         docker --version
         antsibull-changelog --version
       '
@@ -447,7 +459,7 @@ run_vulnerability_scan() {
       --cache-dir /var/cache/trivy \
       --scanners vuln \
       --ignore-unfixed \
-      "${trivy_ignore_args[@]}" \
+      ${trivy_ignore_args[@]+"${trivy_ignore_args[@]}"} \
       --severity HIGH \
       --exit-code 0 \
       "$image"
@@ -462,7 +474,7 @@ run_vulnerability_scan() {
       --cache-dir /var/cache/trivy \
       --scanners vuln \
       --ignore-unfixed \
-      "${trivy_ignore_args[@]}" \
+      ${trivy_ignore_args[@]+"${trivy_ignore_args[@]}"} \
       --severity CRITICAL \
       --exit-code 1 \
       "$image"

--- a/scripts/devtools-container-ci.sh
+++ b/scripts/devtools-container-ci.sh
@@ -158,6 +158,10 @@ validate_container_input() {
       ;;
   esac
 
+  command -v python3 >/dev/null 2>&1 || {
+    echo "ERROR: python3 is required to validate ${label}." >&2
+    exit 1
+  }
   workspace_root="$(pwd -P)"
   if ! resolved="$(
     python3 - "$path" <<'PY'

--- a/scripts/lit-push-ready.py
+++ b/scripts/lit-push-ready.py
@@ -7,6 +7,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -17,11 +18,15 @@ from pathlib import Path
 
 ROOT = Path(os.environ.get("LIT_REPOSITORY_ROOT", Path(__file__).resolve().parents[1])).resolve()
 CONFIG = ROOT / ".lit" / "push-ready.json"
-EVIDENCE = ROOT / ".git" / "lit-push-ready-evidence.json"
 COPILOT = ROOT / ".github" / "copilot-instructions.md"
 AGENTS = ROOT / "AGENTS.md"
 PASS_MARKER = "PUSH_READY: PASS"
 SECRET_PATH_PARTS = {".env", "id_rsa", "id_ed25519", "secrets", "vault-password"}
+SECRET_CONTENT_PATTERNS = (
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    re.compile(r"(?i)(?:api[_-]?key|client[_-]?secret|access[_-]?token|password)\s*[:=]\s*[\"']?[A-Za-z0-9_./+=-]{16,}"),
+    re.compile(r"\bgh[opusr]_[A-Za-z0-9]{20,}\b"),
+)
 
 
 def run(command: list[str], *, capture: bool = False) -> subprocess.CompletedProcess[str]:
@@ -42,11 +47,23 @@ def git_output(*args: str) -> str:
     return result.stdout
 
 
+def evidence_path() -> Path:
+    git_dir = Path(git_output("rev-parse", "--git-dir").strip())
+    if not git_dir.is_absolute():
+        git_dir = ROOT / git_dir
+    return git_dir.resolve() / "lit-push-ready-evidence.json"
+
+
 def tree_fingerprint() -> str:
+    untracked = git_output("ls-files", "--others", "--exclude-standard").splitlines()
     payload = {
         "head": git_output("rev-parse", "HEAD").strip(),
         "status": git_output("status", "--porcelain=v1", "--untracked-files=all"),
-        "diff": git_output("diff", "--binary", "HEAD"),
+        "diff": git_output("diff", "--no-ext-diff", "--binary", "HEAD"),
+        "untracked": {
+            path: hashlib.sha256((ROOT / path).read_bytes()).hexdigest()
+            for path in untracked
+        },
     }
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
@@ -56,8 +73,8 @@ def tree_fingerprint() -> str:
 def load_config() -> dict:
     if not CONFIG.is_file():
         raise RuntimeError(f"missing required configuration: {CONFIG.relative_to(ROOT)}")
-    data = json.loads(CONFIG.read_text())
-    if data.get("version") != 1 or not isinstance(data.get("checks"), list):
+    data = json.loads(CONFIG.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or data.get("version") != 1 or not isinstance(data.get("checks"), list):
         raise RuntimeError("push-ready configuration must use version 1 and define checks")
     return data
 
@@ -71,7 +88,7 @@ def instructions_digest() -> str:
 def check_instruction_contract() -> None:
     expected = instructions_digest()
     marker = f"AGENTS_SHA256: {expected}"
-    if marker not in COPILOT.read_text():
+    if marker not in COPILOT.read_text(encoding="utf-8"):
         raise RuntimeError(
             "Copilot instructions are stale; run "
             "`python3 scripts/lit-push-ready.py sync-instructions`"
@@ -81,7 +98,7 @@ def check_instruction_contract() -> None:
 def sync_instructions() -> None:
     if not AGENTS.is_file() or not COPILOT.is_file():
         raise RuntimeError("AGENTS.md and .github/copilot-instructions.md are required")
-    lines = COPILOT.read_text().splitlines()
+    lines = COPILOT.read_text(encoding="utf-8").splitlines()
     lines = [
         line
         for line in lines
@@ -96,7 +113,7 @@ def sync_instructions() -> None:
             f"<!-- AGENTS_SHA256: {instructions_digest()} -->",
         ]
     )
-    COPILOT.write_text("\n".join(lines) + "\n")
+    COPILOT.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def execute_checks(config: dict) -> list[dict]:
@@ -128,7 +145,7 @@ def changed_paths() -> list[str]:
     return [line[3:] for line in values if len(line) > 3]
 
 
-def ensure_review_safe() -> None:
+def ensure_review_safe(diff: str) -> None:
     unsafe = []
     for path in changed_paths():
         lowered = path.lower()
@@ -138,14 +155,33 @@ def ensure_review_safe() -> None:
         raise RuntimeError(
             "Copilot review refused for secret-like paths: " + ", ".join(sorted(unsafe))
         )
+    if any(pattern.search(diff) for pattern in SECRET_CONTENT_PATTERNS):
+        raise RuntimeError("Copilot review refused because the planned diff contains secret-like content")
+
+
+def planned_diff() -> str:
+    worktree = git_output("diff", "--no-ext-diff", "--unified=40", "HEAD")
+    if worktree:
+        return worktree
+    upstream = run(
+        ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+        capture=True,
+    )
+    if upstream.returncode == 0:
+        candidate = git_output(
+            "diff", "--no-ext-diff", "--unified=40", f"{upstream.stdout.strip()}...HEAD"
+        )
+        if candidate:
+            return candidate
+    return git_output("show", "--no-ext-diff", "--format=", "--unified=40", "HEAD")
 
 
 def copilot_review(config: dict) -> dict:
-    ensure_review_safe()
+    diff = planned_diff()
+    ensure_review_safe(diff)
     executable = shutil.which("copilot")
     if executable is None:
         raise RuntimeError("required Copilot CLI executable is unavailable")
-    diff = git_output("diff", "--no-ext-diff", "--unified=40", "HEAD")
     max_bytes = int(config.get("copilot", {}).get("max_diff_bytes", 200_000))
     encoded = diff.encode()
     if len(encoded) > max_bytes:
@@ -179,7 +215,8 @@ def copilot_review(config: dict) -> dict:
         )
         output.seek(0)
         review = output.read()
-    if result.returncode or PASS_MARKER not in review:
+    final_line = next((line.strip() for line in reversed(review.splitlines()) if line.strip()), "")
+    if result.returncode or final_line != PASS_MARKER:
         print(review)
         raise RuntimeError("Copilot review did not produce a passing result")
     digest = hashlib.sha256(review.encode()).hexdigest()
@@ -193,7 +230,8 @@ def copilot_review(config: dict) -> dict:
 
 
 def write_evidence(config: dict, checks: list[dict], review: dict) -> None:
-    EVIDENCE.parent.mkdir(parents=True, exist_ok=True)
+    evidence = evidence_path()
+    evidence.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "version": 1,
         "tree_fingerprint": tree_fingerprint(),
@@ -204,13 +242,14 @@ def write_evidence(config: dict, checks: list[dict], review: dict) -> None:
         "remote_only_checks": config.get("remote_only_checks", []),
         "created_at_epoch": int(time.time()),
     }
-    EVIDENCE.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    evidence.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def verify_evidence() -> None:
-    if not EVIDENCE.is_file():
+    evidence = evidence_path()
+    if not evidence.is_file():
         raise RuntimeError("push-ready evidence does not exist")
-    payload = json.loads(EVIDENCE.read_text())
+    payload = json.loads(evidence.read_text(encoding="utf-8"))
     if payload.get("tree_fingerprint") != tree_fingerprint():
         raise RuntimeError("push-ready evidence is stale for the current Git tree")
     if payload.get("agents_sha256") != instructions_digest():
@@ -235,10 +274,10 @@ def main() -> int:
         if args.command == "sync-instructions":
             sync_instructions()
             return 0
-        config = load_config()
         check_instruction_contract()
         if args.command == "instructions":
             return 0
+        config = load_config()
         if args.command == "verify":
             verify_evidence()
             return 0
@@ -252,7 +291,7 @@ def main() -> int:
         review = copilot_review(config)
         write_evidence(config, checks, review)
         verify_evidence()
-        print(f"Push-ready evidence: {EVIDENCE}")
+        print(f"Push-ready evidence: {evidence_path()}")
         return 0
     except (OSError, RuntimeError, json.JSONDecodeError) as exc:
         print(f"push-ready: {exc}", file=sys.stderr)

--- a/scripts/lit-push-ready.py
+++ b/scripts/lit-push-ready.py
@@ -21,6 +21,8 @@ CONFIG = ROOT / ".lit" / "push-ready.json"
 COPILOT = ROOT / ".github" / "copilot-instructions.md"
 AGENTS = ROOT / "AGENTS.md"
 PASS_MARKER = "PUSH_READY: PASS"
+EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+CONTRACT_LINE = "<!-- Managed contract: Codex and Copilot must apply AGENTS.md. -->"
 SECRET_PATH_PARTS = {".env", "id_rsa", "id_ed25519", "secrets", "vault-password"}
 SECRET_CONTENT_PATTERNS = (
     re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
@@ -87,8 +89,9 @@ def instructions_digest() -> str:
 
 def check_instruction_contract() -> None:
     expected = instructions_digest()
-    marker = f"AGENTS_SHA256: {expected}"
-    if marker not in COPILOT.read_text(encoding="utf-8"):
+    marker = f"<!-- AGENTS_SHA256: {expected} -->"
+    lines = COPILOT.read_text(encoding="utf-8").splitlines()
+    if lines[-2:] != [CONTRACT_LINE, marker]:
         raise RuntimeError(
             "Copilot instructions are stale; run "
             "`python3 scripts/lit-push-ready.py sync-instructions`"
@@ -104,12 +107,14 @@ def sync_instructions() -> None:
         for line in lines
         if not line.startswith("<!-- AGENTS_SHA256:")
         and line
-        != "<!-- Managed contract: Codex and Copilot must apply AGENTS.md. -->"
+        != CONTRACT_LINE
     ]
+    while lines and not lines[-1]:
+        lines.pop()
     lines.extend(
         [
             "",
-            "<!-- Managed contract: Codex and Copilot must apply AGENTS.md. -->",
+            CONTRACT_LINE,
             f"<!-- AGENTS_SHA256: {instructions_digest()} -->",
         ]
     )
@@ -173,7 +178,9 @@ def planned_diff() -> str:
         )
         if candidate:
             return candidate
-    return git_output("show", "--no-ext-diff", "--format=", "--unified=40", "HEAD")
+    return git_output(
+        "diff", "--no-ext-diff", "--unified=40", EMPTY_TREE, "HEAD"
+    )
 
 
 def copilot_review(config: dict) -> dict:

--- a/scripts/lit-push-ready.py
+++ b/scripts/lit-push-ready.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Create commit-bound local pipeline and Copilot review evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(os.environ.get("LIT_REPOSITORY_ROOT", Path(__file__).resolve().parents[1])).resolve()
+CONFIG = ROOT / ".lit" / "push-ready.json"
+EVIDENCE = ROOT / ".git" / "lit-push-ready-evidence.json"
+COPILOT = ROOT / ".github" / "copilot-instructions.md"
+AGENTS = ROOT / "AGENTS.md"
+PASS_MARKER = "PUSH_READY: PASS"
+SECRET_PATH_PARTS = {".env", "id_rsa", "id_ed25519", "secrets", "vault-password"}
+
+
+def run(command: list[str], *, capture: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.STDOUT if capture else None,
+    )
+
+
+def git_output(*args: str) -> str:
+    result = run(["git", *args], capture=True)
+    if result.returncode:
+        raise RuntimeError(result.stdout.strip())
+    return result.stdout
+
+
+def tree_fingerprint() -> str:
+    payload = {
+        "head": git_output("rev-parse", "HEAD").strip(),
+        "status": git_output("status", "--porcelain=v1", "--untracked-files=all"),
+        "diff": git_output("diff", "--binary", "HEAD"),
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def load_config() -> dict:
+    if not CONFIG.is_file():
+        raise RuntimeError(f"missing required configuration: {CONFIG.relative_to(ROOT)}")
+    data = json.loads(CONFIG.read_text())
+    if data.get("version") != 1 or not isinstance(data.get("checks"), list):
+        raise RuntimeError("push-ready configuration must use version 1 and define checks")
+    return data
+
+
+def instructions_digest() -> str:
+    if not AGENTS.is_file() or not COPILOT.is_file():
+        raise RuntimeError("AGENTS.md and .github/copilot-instructions.md are required")
+    return hashlib.sha256(AGENTS.read_bytes()).hexdigest()
+
+
+def check_instruction_contract() -> None:
+    expected = instructions_digest()
+    marker = f"AGENTS_SHA256: {expected}"
+    if marker not in COPILOT.read_text():
+        raise RuntimeError(
+            "Copilot instructions are stale; run "
+            "`python3 scripts/lit-push-ready.py sync-instructions`"
+        )
+
+
+def sync_instructions() -> None:
+    if not AGENTS.is_file() or not COPILOT.is_file():
+        raise RuntimeError("AGENTS.md and .github/copilot-instructions.md are required")
+    lines = COPILOT.read_text().splitlines()
+    lines = [
+        line
+        for line in lines
+        if not line.startswith("<!-- AGENTS_SHA256:")
+        and line
+        != "<!-- Managed contract: Codex and Copilot must apply AGENTS.md. -->"
+    ]
+    lines.extend(
+        [
+            "",
+            "<!-- Managed contract: Codex and Copilot must apply AGENTS.md. -->",
+            f"<!-- AGENTS_SHA256: {instructions_digest()} -->",
+        ]
+    )
+    COPILOT.write_text("\n".join(lines) + "\n")
+
+
+def execute_checks(config: dict) -> list[dict]:
+    results: list[dict] = []
+    for check in config["checks"]:
+        name = check.get("name")
+        command = check.get("command")
+        if not name or not isinstance(command, list) or not command:
+            raise RuntimeError("each check requires a name and non-empty command array")
+        started = time.monotonic()
+        print(f"==> {name}: {shlex.join(command)}", flush=True)
+        result = run(command)
+        elapsed = round(time.monotonic() - started, 3)
+        results.append(
+            {
+                "name": name,
+                "command": command,
+                "exit_code": result.returncode,
+                "duration_seconds": elapsed,
+            }
+        )
+        if result.returncode:
+            raise RuntimeError(f"check failed: {name}")
+    return results
+
+
+def changed_paths() -> list[str]:
+    values = git_output("status", "--porcelain=v1", "--untracked-files=all").splitlines()
+    return [line[3:] for line in values if len(line) > 3]
+
+
+def ensure_review_safe() -> None:
+    unsafe = []
+    for path in changed_paths():
+        lowered = path.lower()
+        if any(part in lowered for part in SECRET_PATH_PARTS):
+            unsafe.append(path)
+    if unsafe:
+        raise RuntimeError(
+            "Copilot review refused for secret-like paths: " + ", ".join(sorted(unsafe))
+        )
+
+
+def copilot_review(config: dict) -> dict:
+    ensure_review_safe()
+    executable = shutil.which("copilot")
+    if executable is None:
+        raise RuntimeError("required Copilot CLI executable is unavailable")
+    diff = git_output("diff", "--no-ext-diff", "--unified=40", "HEAD")
+    max_bytes = int(config.get("copilot", {}).get("max_diff_bytes", 200_000))
+    encoded = diff.encode()
+    if len(encoded) > max_bytes:
+        raise RuntimeError(f"planned diff exceeds Copilot review limit of {max_bytes} bytes")
+    prompt = (
+        "Review the following planned Lightning IT change. Apply AGENTS.md and "
+        ".github/copilot-instructions.md. Report correctness, security, test, "
+        "scope and expected GitHub Actions problems. Do not modify files or run "
+        "commands. End with exactly 'PUSH_READY: PASS' only when there is no "
+        "blocking finding; otherwise end with 'PUSH_READY: BLOCKED'.\n\n"
+        + diff
+    )
+    started = time.monotonic()
+    with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as output:
+        result = subprocess.run(
+            [
+                executable,
+                "-p",
+                prompt,
+                "--silent",
+                "--available-tools",
+                "view,grep,glob",
+                "--allow-tool",
+                "read",
+            ],
+            cwd=ROOT,
+            check=False,
+            text=True,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+        )
+        output.seek(0)
+        review = output.read()
+    if result.returncode or PASS_MARKER not in review:
+        print(review)
+        raise RuntimeError("Copilot review did not produce a passing result")
+    digest = hashlib.sha256(review.encode()).hexdigest()
+    print(review)
+    return {
+        "command": "copilot -p <review-prompt> --silent --available-tools view,grep,glob --allow-tool read",
+        "duration_seconds": round(time.monotonic() - started, 3),
+        "output_sha256": digest,
+        "result": "pass",
+    }
+
+
+def write_evidence(config: dict, checks: list[dict], review: dict) -> None:
+    EVIDENCE.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": 1,
+        "tree_fingerprint": tree_fingerprint(),
+        "head": git_output("rev-parse", "HEAD").strip(),
+        "agents_sha256": instructions_digest(),
+        "checks": checks,
+        "copilot_review": review,
+        "remote_only_checks": config.get("remote_only_checks", []),
+        "created_at_epoch": int(time.time()),
+    }
+    EVIDENCE.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def verify_evidence() -> None:
+    if not EVIDENCE.is_file():
+        raise RuntimeError("push-ready evidence does not exist")
+    payload = json.loads(EVIDENCE.read_text())
+    if payload.get("tree_fingerprint") != tree_fingerprint():
+        raise RuntimeError("push-ready evidence is stale for the current Git tree")
+    if payload.get("agents_sha256") != instructions_digest():
+        raise RuntimeError("push-ready evidence used different AGENTS.md instructions")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "command",
+        choices=(
+            "instructions",
+            "validate",
+            "review",
+            "push-ready",
+            "verify",
+            "sync-instructions",
+        ),
+    )
+    args = parser.parse_args()
+    try:
+        if args.command == "sync-instructions":
+            sync_instructions()
+            return 0
+        config = load_config()
+        check_instruction_contract()
+        if args.command == "instructions":
+            return 0
+        if args.command == "verify":
+            verify_evidence()
+            return 0
+        if args.command == "validate":
+            execute_checks(config)
+            return 0
+        if args.command == "review":
+            copilot_review(config)
+            return 0
+        checks = execute_checks(config)
+        review = copilot_review(config)
+        write_evidence(config, checks, review)
+        verify_evidence()
+        print(f"Push-ready evidence: {EVIDENCE}")
+        return 0
+    except (OSError, RuntimeError, json.JSONDecodeError) as exc:
+        print(f"push-ready: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-host-parity.sh
+++ b/scripts/verify-host-parity.sh
@@ -37,6 +37,7 @@ image="local/lightning-it-devtools:host-parity"
 # The single-quoted command is intentionally expanded in the container.
 # shellcheck disable=SC2016
 "$engine" run --rm \
+  --network none \
   --read-only \
   --cap-drop ALL \
   --security-opt no-new-privileges=true \

--- a/scripts/verify-host-parity.sh
+++ b/scripts/verify-host-parity.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_root="$(git rev-parse --show-toplevel)"
+command -v git >/dev/null 2>&1 || {
+  echo "git is required for the host parity probe." >&2
+  exit 1
+}
+command -v python3 >/dev/null 2>&1 || {
+  echo "python3 is required for the host parity probe." >&2
+  exit 1
+}
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "The host parity probe must run inside a Git working tree." >&2
+  exit 1
+}
 cd "$repo_root"
 
 engine="${WUNDER_CONTAINER_ENGINE:-}"

--- a/scripts/verify-host-parity.sh
+++ b/scripts/verify-host-parity.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+engine="${WUNDER_CONTAINER_ENGINE:-}"
+if [ -z "$engine" ]; then
+  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    engine=docker
+  elif command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
+    engine=podman
+  else
+    echo "No usable Docker or Podman runtime found." >&2
+    exit 1
+  fi
+fi
+
+case "$engine" in
+  docker|podman) ;;
+  *) echo "Unsupported runtime: $engine" >&2; exit 1 ;;
+esac
+
+os="$(uname -s)"
+arch="$(uname -m)"
+case "${os}/${arch}" in
+  Linux/x86_64|Darwin/arm64) ;;
+  *)
+    echo "Host ${os}/${arch} is outside the REP-50 acceptance matrix." >&2
+    exit 1
+    ;;
+esac
+
+started="$(date +%s)"
+image="local/lightning-it-devtools:host-parity"
+"$engine" build --build-arg COLLECTION_PROFILE=public -t "$image" .
+# The single-quoted command is intentionally expanded in the container.
+# shellcheck disable=SC2016
+"$engine" run --rm \
+  --read-only \
+  --cap-drop ALL \
+  --security-opt no-new-privileges=true \
+  --tmpfs /tmp:rw,exec,nosuid,nodev,size=2g \
+  "$image" sh -ec '
+    export XDG_CACHE_HOME=/tmp/.cache
+    mkdir -p "$XDG_CACHE_HOME"
+    test "$(id -u)" != 0
+    python3 --version
+    terraform version
+    ansible --version
+    actionlint --version
+    node --version
+    copilot --version
+  '
+finished="$(date +%s)"
+
+python3 - "$os" "$arch" "$engine" "$started" "$finished" <<'PY'
+import json
+import sys
+
+os_name, arch, runtime, started, finished = sys.argv[1:]
+print(json.dumps({
+    "version": 1,
+    "host_os": os_name,
+    "host_arch": arch,
+    "runtime": runtime,
+    "duration_seconds": int(finished) - int(started),
+    "result": "pass",
+}, sort_keys=True))
+PY


### PR DESCRIPTION
Implements #361. Depends on lightning-it/shared-assets-lit#602 for the managed baseline.

Adds pinned Node.js, npm and GitHub Copilot CLI to the UBI 9 devtool image, a current-source Dev Container, a fail-closed host parity probe, and local push-ready validation. The container contract now verifies Copilot under a narrowly scoped executable cache mount.

Validation:
- macOS Apple Silicon / Docker host-parity probe: PASS
- Node 22.23.1, npm 12.0.1, Copilot CLI 1.0.74
- Trivy CRITICAL scan: 0 findings
- Renovate config validator: PASS
- shellcheck and instruction parity: PASS
- Copilot CLI review: PUSH_READY: PASS

RHEL and Ubuntu host evidence remain explicit acceptance-matrix follow-ups before #361 can be closed.